### PR TITLE
Remove padding-left for a radio button group

### DIFF
--- a/app/assets/stylesheets/responsive_active_admin/_forms.scss
+++ b/app/assets/stylesheets/responsive_active_admin/_forms.scss
@@ -28,7 +28,7 @@ form {
 
       &:not(.has_many_fields) ol {
         @include responsive {
-          width: 80%;
+          padding-left: 0;
         }
       }
     }


### PR DESCRIPTION
ActiveAdmin has a line `padding: 0 0 0 20%;` and I guess this `width: 80%;` responds to it, but I think you can just remove the padding at the left.

What do you think?  Oh, and thanks for this cool gem!
